### PR TITLE
Commerce, Auth: send analytics events to GA4 and Pixel

### DIFF
--- a/packages/auth/components/login.tsx
+++ b/packages/auth/components/login.tsx
@@ -11,6 +11,7 @@ import { cn } from '@hanzo/ui/util'
 import { useAuth } from '../service'
 import { Facebook, Google, GitHub } from '../icons'
 import EmailPasswordForm from './email-password-form'
+import { sendGAEvent } from '../util/analytics'
 
 const Login: React.FC<PropsWithChildren & {
   redirectUrl?: string,
@@ -52,6 +53,9 @@ const Login: React.FC<PropsWithChildren & {
     try {
       const res = await auth.loginEmailAndPassword(email, password)
       if (res.success) {
+        sendGAEvent('login', {
+          method: 'email'
+        })
         succeed()
       }
     } 
@@ -81,6 +85,9 @@ const Login: React.FC<PropsWithChildren & {
     setIsLoading(true)
     const res = await auth.loginWithProvider(provider)
     if (res.success ) {
+      sendGAEvent('login', {
+        method: provider
+      })
       succeed()
     }
     setIsLoading(false)

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanzo/auth",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Library with Firebase authentication.",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/auth/util/analytics.ts
+++ b/packages/auth/util/analytics.ts
@@ -1,0 +1,21 @@
+declare global {
+  interface Window {
+    fbq: Function;
+    gtag: Function;
+  }
+}
+
+// https://developers.facebook.com/docs/meta-pixel/reference
+const sendFBEvent = (name: string, options = {}) => {
+  window.fbq('track', name, options)
+}
+
+// https://developers.google.com/analytics/devguides/collection/ga4/ecommerce?client_type=gtag
+const sendGAEvent = (name: string, options = {}) => {
+  window.gtag('event', name, options)
+}
+
+export {
+  sendFBEvent,
+  sendGAEvent,
+}

--- a/packages/commerce/components/add-to-cart-widget.tsx
+++ b/packages/commerce/components/add-to-cart-widget.tsx
@@ -7,6 +7,7 @@ import { cn } from '@hanzo/ui/util'
 
 import { Icons } from './Icons'
 import type { LineItem } from '../types'
+import { sendFBEvent, sendGAEvent } from '../util/analytics'
 
 const AddToCartWidget: React.FC<{ 
   item: LineItem
@@ -50,7 +51,27 @@ const AddToCartWidget: React.FC<{
     else {
       toast(`Changed quantity to ${old + 1} for ${item.title}.`)
     }
-
+    sendGAEvent('add_to_cart', {
+      items: [{
+        item_id: item.sku,
+        item_name: item.title,
+        item_category: item.categoryId,
+        price: item.price,
+        quantity: item.quantity
+      }],
+      value: item.price,
+      currency: 'USD',
+    })
+    sendFBEvent('AddToCart', {
+      content_ids: [item.sku],
+      contents: [{
+        id: item.sku,
+        quantity: item.quantity
+      }],
+      content_name: item.title,
+      value: item.price,
+      currency: 'USD',
+    })
   }
 
   const dec = () => {
@@ -65,6 +86,17 @@ const AddToCartWidget: React.FC<{
     else {
       toast(`Changed quantity to ${old - 1} for ${item.title}.`)
     }
+    sendGAEvent('remove_from_cart', {
+      items: [{
+        item_id: item.sku,
+        item_name: item.title,
+        item_category: item.categoryId,
+        price: item.price,
+        quantity: item.quantity
+      }],
+      value: item.price,
+      currency: 'USD',
+    })
   }
 
   return ( item.isInCart ? (

--- a/packages/commerce/components/cart-panel/index.tsx
+++ b/packages/commerce/components/cart-panel/index.tsx
@@ -9,6 +9,7 @@ import { useCommerce } from '../../service/context'
 import { formatPrice } from '../../util'
 
 import CartLineItem from './cart-line-item'
+import { sendFBEvent, sendGAEvent } from '../../util/analytics'
 
 const CartPanel: React.FC<PropsWithChildren & {
   className?: string
@@ -31,6 +32,31 @@ const CartPanel: React.FC<PropsWithChildren & {
     return <div />
   }
 
+  const showCheckout = () => {
+    sendGAEvent('begin_checkout', {
+      currency: 'USD',
+      value: cmmc.cartTotal,
+      items: cmmc.cartItems.map((item) => ({
+        item_id: item.sku,
+        item_name: item.title,
+        item_category: item.categoryId,
+        price: item.price,
+        quantity: item.quantity
+      })),
+    })
+    sendFBEvent('InitiateCheckout', {
+      content_ids: cmmc.cartItems.map((item) => item.sku),
+      contents: cmmc.cartItems.map(item => ({
+        id: item.sku,
+        quantity: item.quantity
+      })),
+      num_items: cmmc.cartItems.length,
+      value: cmmc.cartTotal,
+      currency: 'USD',
+    })
+    onCheckoutOpen && onCheckoutOpen()
+  }
+
   return (
     <div className={cn('border p-4 rounded-lg', className)}>
       {children}
@@ -50,7 +76,7 @@ const CartPanel: React.FC<PropsWithChildren & {
             variant='primary' 
             rounded='lg' 
             className='mt-12 mx-auto w-full' 
-            onClick={onCheckoutOpen}
+            onClick={showCheckout}
           >
             Checkout
           </Button>

--- a/packages/commerce/components/checkout-panel/payment/index.tsx
+++ b/packages/commerce/components/checkout-panel/payment/index.tsx
@@ -14,6 +14,7 @@ import PayWithBankTransfer from './pay-with-bank-transfer'
 import PayWithCard from './pay-with-card'
 import { useCommerce } from '../../../service/context'
 import type { TransactionStatus } from '../../../types'
+import { sendFBEvent, sendGAEvent } from '../../../util/analytics'
 
 const contactFormSchema = z.object({
   name: z.string().min(1, 'Enter your full name.'),
@@ -56,6 +57,26 @@ const Payment: React.FC<{
       setOrderId(id)
     }
     if (id) {
+      sendGAEvent('add_payment_info', {
+        items: cmmc.cartItems.map((item) => ({
+          item_id: item.sku,
+          item_name: item.title,
+          item_category: item.categoryId,
+          price: item.price,
+          quantity: item.quantity
+        })),
+        value: cmmc.cartTotal,
+        currency: 'USD',
+        payment_type: paymentInfo.paymentMethod ?? ''
+      })
+      sendFBEvent('AddPaymentInfo', {
+        contents: cmmc.cartItems.map(item => ({
+          id: item.sku,
+          quantity: item.quantity
+        })),
+        value: cmmc.cartTotal,
+        currency: 'USD'
+      })
       await cmmc.updateOrderPaymentInfo(id, paymentInfo)
     }
   }

--- a/packages/commerce/components/checkout-panel/shipping-info.tsx
+++ b/packages/commerce/components/checkout-panel/shipping-info.tsx
@@ -21,11 +21,10 @@ import {
   SelectValue 
 } from '@hanzo/ui/primitives'
 
-import { useAuth } from '@hanzo/auth/service'
-
 import { useCommerce } from '../..'
 
 import { countries } from './countries'
+import { sendGAEvent } from '../../util/analytics'
 
 const shippingFormSchema = z.object({
   addressLine1: z.string().min(2, 'Address must be at least 2 characters.'),
@@ -43,7 +42,6 @@ const ShippingInfo: React.FC<{
   orderId,
   setStep
 }) => { 
-  const auth = useAuth()
   const cmmc = useCommerce()
   
   const shippingForm = useForm<z.infer<typeof shippingFormSchema>>({
@@ -62,6 +60,18 @@ const ShippingInfo: React.FC<{
     if (orderId) {
       await cmmc.updateOrderShippingInfo(orderId, values)
     }
+    sendGAEvent('add_shipping_info', {
+      items: cmmc.cartItems.map((item) => ({
+        item_id: item.sku,
+        item_name: item.title,
+        item_category: item.categoryId,
+        price: item.price,
+        quantity: item.quantity
+      })),
+      num_items: cmmc.cartItems.length,
+      value: cmmc.cartTotal,
+      currency: 'USD',
+    })
     setStep(3)
   }
 

--- a/packages/commerce/components/facet-values-widget/facet-image.tsx
+++ b/packages/commerce/components/facet-values-widget/facet-image.tsx
@@ -4,25 +4,25 @@ import Image from 'next/image'
 import type { FacetValueDesc } from '../../types'
 
 const ICON_SIZE = 20
-const SVG_MULT = 1.5
 
 const FacetImage: React.FC<{
   facetValueDesc: FacetValueDesc
 }> = ({
   facetValueDesc
 }) => {
+
   const {
     img,
     imgAR: ar,
     label
   } = facetValueDesc
 
-
   if (!img) {
     return null
   }
-  const isURL = typeof img === 'string'
-  if (isURL) {
+
+    // url
+  if (typeof img === 'string') {
     return (
       <Image 
         src={img as string} 
@@ -33,42 +33,8 @@ const FacetImage: React.FC<{
       />
     )
   }
-
+    // ReactNode
   return img as React.ReactNode
-
-    // Otherwise, assume it's a ReactNode of an imported SVG
-
-    // If it's not square, center it in the appropriate dimension
-    /*
-  const svgStyle: any = { position: 'relative' }
-  if (ar) {
-    if (ar < 1) {
-      const w = ICON_SIZE * SVG_MULT
-      svgStyle.top = (( 1 / ar - 1) * w) / 2
-    }
-    else if (ar > 1) {
-      const h = ICON_SIZE * SVG_MULT
-      svgStyle.left = (((1 - ar) * h) / 2)
-    }
-  }
-
-  return (
-    <span 
-      className='flex justify-center items-center overflow-hidden ' 
-      style={{
-        color: 'inherit',
-        width: ICON_SIZE * SVG_MULT, 
-        height: ICON_SIZE * SVG_MULT,
-      }} 
-    >
-      {React.cloneElement(facetValueDesc.img as React.ReactElement<any>, {
-        width: (facetValueDesc.imgAR ?? 1) * ICON_SIZE * SVG_MULT, 
-        height: SVG_MULT * ICON_SIZE,
-        style: svgStyle
-      })}
-    </span>
-  )
-  */
 } 
 
 export default FacetImage

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanzo/commerce",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Library with shopping cart components.",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
@@ -37,7 +37,7 @@
     "square": "^35.0.0"
   },
   "peerDependencies": {
-    "@hanzo/auth": "^2.2.1",
+    "@hanzo/auth": "^2.3.0",
     "@hanzo/ui": "^3.0.7",
     "@hookform/resolvers": "^3.3.4",
     "firebase": "^10.8.0",

--- a/packages/commerce/util/analytics.ts
+++ b/packages/commerce/util/analytics.ts
@@ -1,0 +1,21 @@
+declare global {
+  interface Window {
+    fbq: Function;
+    gtag: Function;
+  }
+}
+
+// https://developers.facebook.com/docs/meta-pixel/reference
+const sendFBEvent = (name: string, options = {}) => {
+  window.fbq('track', name, options)
+}
+
+// https://developers.google.com/analytics/devguides/collection/ga4/ecommerce?client_type=gtag
+const sendGAEvent = (name: string, options = {}) => {
+  window.gtag('event', name, options)
+}
+
+export {
+  sendFBEvent,
+  sendGAEvent,
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,7 +317,7 @@ importers:
   packages/commerce:
     dependencies:
       '@hanzo/auth':
-        specifier: ^2.2.1
+        specifier: ^2.3.0
         version: link:../auth
       '@hanzo/ui':
         specifier: ^3.0.7


### PR DESCRIPTION
GA4 events:
- login 
- purchase 
- add_payment_info 
- add_shipping_info 
- add_to_cart 
- begin_checkout 
- purchase 
- remove_from_cart 
- view_cart 

Meta Pixel events:
- AddPaymentInfo
- AddToCart
- InitiateCheckout
- Purchase

requires bump of hanzo/auth and hanzo/commerce